### PR TITLE
QA環境のデプロイ時間を14:15 JSTに変更

### DIFF
--- a/.github/workflows/deploy_trigger_qa.yml
+++ b/.github/workflows/deploy_trigger_qa.yml
@@ -5,8 +5,8 @@ on:
   schedule:
     # 14:00 JST on 2nd and 4th Thursday of every month (5:00 UTC)
     # - cron: '0 5 * * 4'
-    # 13:30 JST on 2025-08-17 (4:30 UTC)
-    - cron: '30 4 17 8 *'
+    # 14:15 JST on 2025-08-17 (5:15 UTC)
+    - cron: '15 5 17 8 *'
 
 jobs:
   check-schedule:


### PR DESCRIPTION
## Summary
- QA環境のデプロイ実行時間を2025年8月17日14:15（日本時間）に変更
- cron設定を `30 4 17 8 *` から `15 5 17 8 *` に更新（UTC 5:15 = JST 14:15）

## Test plan
- [ ] ワークフローの文法チェック
- [ ] スケジュール設定の確認
- [ ] 実行時間の検証

🤖 Generated with [Claude Code](https://claude.ai/code)