### PR TITLE
QA環境のデプロイ時間を15:00 JSTに変更

### DIFF
--- a/.github/workflows/deploy_trigger_qa.yml
+++ b/.github/workflows/deploy_trigger_qa.yml
@@ -5,8 +5,8 @@ on:
   schedule:
     # 14:00 JST on 2nd and 4th Thursday of every month (5:00 UTC)
     # - cron: '0 5 * * 4'
-    # 14:30 JST on 2025-08-17 (5:30 UTC)
-    - cron: '30 5 17 8 *'
+    # 15:00 JST on 2025-08-17 (6:00 UTC)
+    - cron: '0 6 17 8 *'
 
 jobs:
   check-schedule:


### PR DESCRIPTION
## Summary
- QA環境のデプロイ実行時間を2025年8月17日15:00（日本時間）に変更
- cron設定を `30 5 17 8 *` から `0 6 17 8 *` に更新（UTC 6:00 = JST 15:00）

## Test plan
- [ ] ワークフローの文法チェック
- [ ] スケジュール設定の確認
- [ ] 実行時間の検証（15:00 JST）

🤖 Generated with [Claude Code](https://claude.ai/code)